### PR TITLE
conf include directory conf.d to allow custom configuration for examp…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,5 @@
 squid_port: 3128
 
 squid_cache_dir: ufs /var/spool/squid 100 16 256
+
+# squid_conf_include_dir: /etc/squid/conf.d

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,22 @@
     owner: "{{ squid_user }}"
     group: "{{ squid_group }}"
 
+- name: create config include directory
+  file:
+    path: "{{ squid_conf_include_dir }}"
+    state: directory
+    owner: "{{ squid_user }}"
+    group: "{{ squid_group }}"
+  when: squid_conf_include_dir is defined
+
+- name: create dummy config file
+  copy:
+    dest: "{{ squid_conf_include_dir }}/dummy.conf"
+    content: "# prevent empty dir breaking squid"
+    owner: "{{ squid_user }}"
+    group: "{{ squid_group }}"
+  when: squid_conf_include_dir is defined
+
 - name: flush_handlers
   meta: flush_handlers
 
@@ -47,3 +63,4 @@
     name: "{{ squid_service }}"
     state: started
     enabled: yes
+

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -69,3 +69,7 @@ acl {{ acl.name }} {{ acl.classifier }} {{ acl.value }}
 cache {{ rule.decision }} {{ rule.acl }}
 {% endfor %}
 {% endif %}
+
+{% if squid_conf_include_dir is defined %}
+include {{ squid_conf_include_dir }}/*.conf
+{% endif %}


### PR DESCRIPTION
I wanted to use this role to configure squid to use a upstream proxy server using something like

```
cache_peer 10.0.2.2 parent 8888 0 no-query default
never_direct allow all
```

