### PR TITLE
Create users and group first to prevent failure on Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,20 +3,6 @@
 - name: include assert.yml
   include_tasks: assert.yml
 
-- name: install squid
-  package:
-    name: "{{ squid_packages }}"
-    state: present
-
-- name: configure squid
-  template:
-    src: "{{ squid_config_file }}.j2"
-    dest: "{{ squid_config_directory }}/{{ squid_config_file }}"
-    mode: "0644"
-  notify:
-    - test squid configuration
-    - restart squid
-
 - name: create group
   group:
     name: "{{ squid_group }}"
@@ -32,6 +18,21 @@
     home: /var/spool/squid
     shell: /sbin/nologin
     system: yes
+
+- name: install squid
+  package:
+    name: "{{ squid_packages }}"
+    state: present
+
+- name: configure squid
+  template:
+    src: "{{ squid_config_file }}.j2"
+    dest: "{{ squid_config_directory }}/{{ squid_config_file }}"
+    mode: "0644"
+  notify:
+    - test squid configuration
+    - restart squid
+
 
 - name: create cache directory
   file:


### PR DESCRIPTION
---
name: Move creation of group and user before installing Squid.
about: Prevent failure on Debian. Closes #2.
---
**Describe the change**
A clear and concise description of what the pull request is.
Move creation of group and user before installing Squid.
This prevents failure on Debian. 
It closes #2 

**Testing**

I ran the role in my playbook on a clean environment before and after the change
* Before it failed with #2. 
* After it worked

It was only tested on Debian10.