### PR TITLE
Skip service restart in check mode

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,4 @@
   service:
     name: "{{ squid_service }}"
     state: restarted
+  when: not ansible_check_mode


### PR DESCRIPTION
Default behaviour has been changed in ansible 2.10, check mode was failing
without this change.

See https://github.com/ansible/ansible/issues/72721 for more information.