### PR TITLE
Skip service management in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,3 +50,5 @@
     name: "{{ squid_service }}"
     state: started
     enabled: yes
+  when:
+    - not ansible_check_mode | bool


### PR DESCRIPTION
Same problem which was fixed in 6c1b620b, this occurrence was missed from the previous PR.