### PR TITLE
Add support for the logformat option

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -91,3 +91,12 @@
     label: "{{ item.acl }}"
   when:
     - squid_rules is defined
+
+- name: Test if squid_logformat is set correctly
+  ansible.builtin.assert:
+    that:
+      - squid_logformat is string
+      - squid_logformat.split(" ") | length > 1
+    quiet: yes
+  when:
+    - squid_logformat is defined

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -40,6 +40,10 @@ cache_replacement_policy {{ squid_cache_replacement_policy }}
 maximum_object_size {{ squid_maximum_object_size_mb }} MB
 {% endif %}
 
+{% if squid_logformat is defined %}
+logformat {{ squid_logformat }}
+{% endif %}
+
 {% if squid_access_log is defined %}
 access_log {{ squid_access_log }}
 {% endif %}


### PR DESCRIPTION
---
name: Pull request
about: Add support for the logformat config option

---

**Describe the change**
Squid allows customization of the format by which log messages are written to the access log. This PR adds functionality to configure the log format with Squid's `logformat` option (http://www.squid-cache.org/Doc/config/logformat/).

Another recent PR added support for the `access_log` option (http://www.squid-cache.org/Doc/config/access_log/). Which goes hand in hand with the `logformat` option. To activate one's custom log format you need to select it by name in the `access_log` option. :+1: 

**Testing**
I have tested this change locally (with and without `squid_logformat` defined) and tested against a proxy server of my current client. 
