### PR TITLE
Extend config to allow passing a hostname.

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: assert | Test squid_host
+  ansible.builtin.assert:
+    that:
+      - squid_host is string
+      - squid_host is not none
+    quiet: true
+  when:
+    - squid_host is defined
+
 - name: assert | Test squid_port
   ansible.builtin.assert:
     that:

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 
-http_port {{ squid_port }}
+http_port {% if squid_host is defined %}{{ squid_host }}:{% endif %}{{ squid_port }}
 
 cache_effective_user {{ squid_user }}
 cache_effective_group {{ squid_group }}


### PR DESCRIPTION

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
Extends squid config to allow passing a host to bind to.

Particularly useful if you need to bind squid to  localhost.
https://www.squid-cache.org/Doc/config/http_port/

**Testing**
Local squid deployment binding against "127.0.0.1"
